### PR TITLE
fix: validate semver format in release tag lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           TAG=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || echo "")
-          if [ -z "$TAG" ]; then
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n1)
           fi
           echo "tag=${TAG:-v0.0.0}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fix release workflow failing on first run when no GitHub Releases exist
- `gh api releases/latest` returns 404 error JSON which was incorrectly used as the tag value
- Changed empty-string check (`-z`) to semver format validation (`=~ ^v[0-9]+\.[0-9]+\.[0-9]+$`)
- Falls back to `git tag` then `v0.0.0` when API response is invalid

## Root cause

```
NEXT_TAG: v{"message":"Not Found","documentation_url":"...","status":"404"}
```

The error JSON passed the `-z` check (not empty) but is not a valid semver tag.

## Test plan

- [ ] Merge this PR and verify Release workflow creates `v0.2.0` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)