### PR TITLE
fix: add setup-python to avoid PEP 668 externally managed error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,6 +111,11 @@ runs:
             ;;
         esac
 
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -50,6 +50,11 @@ runs:
             ;;
         esac
 
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 


### PR DESCRIPTION
## Summary
- Ubuntu 23.04+ の PEP 668 により `uv pip install --system` が "externally managed" エラーで失敗する問題を修正
- `actions/setup-python@v5` (Python 3.11) を uv インストール前に追加し、non-externally-managed な Python 環境を提供
- `action.yml`（root action）と `actions/setup/action.yml`（standalone action）の両方に適用

## Test plan
- [ ] 別リポジトリから `uses: ta93abe/dbt-jobs@fix/setup-python-for-pep668` で呼び出して `uv pip install --system` が成功すること
- [ ] `dbt --version` でインストール確認ができること
- [ ] `npx yaml-lint action.yml actions/setup/action.yml` が通ること (確認済み)

Generated with [Claude Code](https://claude.com/claude-code)