### PR TITLE
feat: fallback to full build when production manifest is unavailable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -287,8 +287,24 @@ runs:
             args += ["--target", target]
         if threads and "--threads" not in args:
             args += ["--threads", threads]
-        if deferral and manifest_found == "true" and "state:" in cmd and "--defer" not in args:
+        has_state_selector = any("state:" in a for a in args)
+
+        if deferral and manifest_found == "true" and has_state_selector and "--defer" not in args:
             args += ["--defer", "--state", "./prod-manifest"]
+        elif has_state_selector and manifest_found != "true":
+            print("::warning::No production manifest found. Removing state: selectors and running full build.")
+            args = [a for a in args if "state:" not in a]
+            # Clean up empty --select / --exclude flags
+            cleaned = []
+            skip_next = False
+            for i, a in enumerate(args):
+                if skip_next:
+                    skip_next = False
+                    continue
+                if a in ("--select", "--exclude", "-s") and (i + 1 >= len(args) or args[i + 1].startswith("-")):
+                    continue
+                cleaned.append(a)
+            args = cleaned
 
         print(f"Running: {' '.join(shlex.quote(a) for a in args)}")
 


### PR DESCRIPTION
## Summary
- マニフェストが見つからない場合に `state:` セレクタ（例: `--select state:modified+`）を自動除外してフルビルドにフォールバック
- `::warning::` でフォールバック発生をユーザーに通知
- 空になった `--select` / `--exclude` フラグもクリーンアップ
- 初回 CI 実行時（merge/deploy の artifacts がまだない場合）にエラーせず動作するようになる

### 動作例
| コマンド | マニフェストあり | マニフェストなし |
|----------|-----------------|-----------------|
| `dbt build --select state:modified+` | `dbt build --select state:modified+ --defer --state ./prod-manifest` | `dbt build` (フルビルド) |
| `dbt build --select state:modified+ tag:critical` | そのまま + defer | `dbt build --select tag:critical` |

## Test plan
- [ ] マニフェストなしの初回 CI 実行で `state:modified+` が除外されフルビルドが成功すること
- [ ] マニフェストありの CI 実行で従来通り `--defer --state` が注入されること
- [ ] `::warning::` メッセージが GitHub Actions の annotations に表示されること
- [ ] `npx yaml-lint action.yml` が通ること (確認済み)

Generated with [Claude Code](https://claude.com/claude-code)