### PR TITLE
fix: Use absolute path for --state to fix project-dir resolution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -290,7 +290,7 @@ runs:
         has_state_selector = any("state:" in a for a in args)
 
         if deferral and manifest_found == "true" and has_state_selector and "--defer" not in args:
-            args += ["--defer", "--state", "./prod-manifest"]
+            args += ["--defer", "--state", os.path.abspath("./prod-manifest")]
         elif has_state_selector and manifest_found != "true":
             print("::warning::No production manifest found. Removing state: selectors and running full build.")
             args = [a for a in args if "state:" not in a]


### PR DESCRIPTION
## Summary
- `--state ./prod-manifest` を `--state <absolute-path>` に修正
- dbt は `--state` の相対パスを `--project-dir` からの相対パスとして解決するため、`project-dir` がリポジトリルート以外（例: `transform/core`）の場合に manifest が見つからないバグを修正

## Root cause
dbt resolves `--state` relative to `--project-dir`, not the working directory. When `project-dir: transform/core` is set, `--state ./prod-manifest` resolves to `transform/core/prod-manifest/manifest.json` which doesn't exist.

## Test plan
- [ ] `project-dir` がリポジトリルート以外の場合に `state:modified+` が正しく動作すること
- [ ] `project-dir` がデフォルト (`.`) の場合も引き続き動作すること

Generated with [Claude Code](https://claude.com/claude-code)